### PR TITLE
Show target duration in workout timer, add version badge to header

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -84,7 +84,13 @@ jobs:
         # test app, so grabbing the newest work-in-progress build doesn't require digging through
         # this run's artifact list - install this over the previous dev build any time to try the
         # latest work without touching the real (`main`-gated) app at all.
-        if: github.ref == 'refs/heads/claude/android-routines-app-mvp-gjl4kh'
+        #
+        # Tracks any non-main branch rather than one hardcoded name - a prior version pinned this
+        # to a single working branch (claude/android-routines-app-mvp-gjl4kh), which silently
+        # stopped publishing the moment a later session used a differently-named branch (e.g.
+        # claude/new-session-r4rs03), leaving latest-android-dev stale for days with no error.
+        # Matches this workflow's own catch-all `branches: ['**']` push trigger.
+        if: github.ref != 'refs/heads/main'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: latest-android-dev

--- a/android/app/src/main/java/com/tharuka/routines/workout/QuantityTimerScreen.kt
+++ b/android/app/src/main/java/com/tharuka/routines/workout/QuantityTimerScreen.kt
@@ -1,0 +1,60 @@
+@file:OptIn(androidx.compose.material3.ExperimentalMaterial3Api::class)
+
+package com.tharuka.routines.workout
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+/**
+ * The "pure timer" counterpart of WorkoutSessionScreen - launched by the same
+ * WorkoutSessionActivity/WorkoutTimerService/WorkoutSessionPlugin infrastructure (see that
+ * Activity's pureTimer branch) for a quantity task set up as a timer (RoutineForm's quantity
+ * "Input as: Timer" mode). Deliberately just a TopAppBar plus the shared DurationTimer - no
+ * exercise chips, PR/volume stats bar, or weight field, since none of that applies to a plain
+ * quantity target. Reusing the real workout session's native host (not a plain in-WebView JS
+ * timer) is what lets this survive backgrounding/screen-lock and run for a long time via the
+ * same foreground service + chronometer notification a real workout gets - a setInterval inside
+ * the WebView would be throttled/suspended the moment the app backgrounds.
+ */
+@Composable
+fun QuantityTimerScreen(
+    taskTitle: String,
+    targetSeconds: Int,
+    initialSeconds: Int?,
+    onLog: (Int) -> Unit,
+    onClose: () -> Unit,
+) {
+    Scaffold(
+        containerColor = AppPalette.Background,
+        topBar = {
+            TopAppBar(
+                title = { Text(taskTitle, fontWeight = FontWeight.Bold) },
+                actions = {
+                    IconButton(onClick = onClose) { Text("✕", fontSize = 18.sp) }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(containerColor = AppPalette.Background),
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier.padding(padding).fillMaxSize().padding(horizontal = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            DurationTimer(targetSeconds = targetSeconds, initialSeconds = initialSeconds, onLog = onLog)
+        }
+    }
+}

--- a/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionActivity.kt
+++ b/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionActivity.kt
@@ -54,11 +54,48 @@ class WorkoutSessionActivity : ComponentActivity() {
         taskId = payload?.optString("taskId")
         dateKey = payload?.optString("dateKey")
         val taskTitle = payload?.optString("taskTitle") ?: ""
+        // A quantity task set up as a timer (RoutineForm's "Input as: Timer" mode) launches this
+        // same Activity/foreground-service/plugin with a much smaller payload - just a target,
+        // no exercises/logs/workoutLogSources at all - and renders QuantityTimerScreen instead of
+        // the full WorkoutSessionScreen. Reusing this host (rather than a plain in-WebView JS
+        // timer) is what lets a long-running quantity timer survive backgrounding/screen-lock via
+        // the same real foreground service + chronometer notification a workout session gets.
+        val pureTimer = payload?.optBoolean("pureTimer", false) ?: false
+
+        startTimerServiceOncePermitted(taskTitle)
+
+        if (pureTimer) {
+            val targetSeconds = payload?.optIntOrNull("targetSeconds") ?: 0
+            val initialSeconds = payload?.optIntOrNull("initialSeconds")
+            setContent {
+                MaterialTheme(colorScheme = WorkoutColorScheme) {
+                    Surface {
+                        QuantityTimerScreen(
+                            taskTitle = taskTitle,
+                            targetSeconds = targetSeconds,
+                            initialSeconds = initialSeconds,
+                            onLog = { seconds ->
+                                val event = JSObject()
+                                event.put("taskId", taskId)
+                                event.put("dateKey", dateKey)
+                                event.put("seconds", seconds)
+                                WorkoutSessionBridge.onQuantityTimerLogged?.invoke(event)
+                                // A pure timer logs one value, not a sequence of sets - nothing
+                                // more to do in this screen once it's logged, so close it the same
+                                // way tapping the X does.
+                                finishWithResult()
+                            },
+                            onClose = { finishWithResult() },
+                        )
+                    }
+                }
+            }
+            return
+        }
+
         val exercises = parseExercises(payload?.optJSONArray("exercises"))
         val logsForDate = parseLogsForDate(payload?.optJSONObject("logsForDate"))
         val workoutLogSources = parseWorkoutLogSources(payload?.optJSONArray("workoutLogSources"))
-
-        startTimerServiceOncePermitted(taskTitle)
 
         setContent {
             MaterialTheme(colorScheme = WorkoutColorScheme) {

--- a/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionBridge.kt
+++ b/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionBridge.kt
@@ -9,4 +9,9 @@ import com.getcapacitor.JSObject
  */
 object WorkoutSessionBridge {
     var onSetLogged: ((JSObject) -> Unit)? = null
+
+    // Fired once when a "pure timer" (quantity-as-timer) session logs its one value - see
+    // WorkoutSessionActivity's pureTimer branch. A separate field rather than reusing onSetLogged
+    // since a pure timer has no Exercise/setIndex at all, just {taskId, dateKey, seconds}.
+    var onQuantityTimerLogged: ((JSObject) -> Unit)? = null
 }

--- a/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionPlugin.kt
+++ b/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionPlugin.kt
@@ -18,6 +18,12 @@ class WorkoutSessionPlugin : Plugin() {
         WorkoutSessionBridge.onSetLogged = { data ->
             notifyListeners("workoutSetLogged", data, true)
         }
+        // Fired by the "pure timer" (quantity-as-timer) flow - see WorkoutSessionActivity's
+        // pureTimer branch and QuantityTimerScreen. Same start()/plugin registration as a real
+        // workout session; only the payload shape and this one extra listener differ.
+        WorkoutSessionBridge.onQuantityTimerLogged = { data ->
+            notifyListeners("quantityTimerLogged", data, true)
+        }
     }
 
     @PluginMethod

--- a/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionScreen.kt
+++ b/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionScreen.kt
@@ -707,6 +707,15 @@ private fun DurationTimer(
                 Text("${elapsed}s", fontSize = 48.sp, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.onBackground)
                 Text("Logged", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
+            if (hasTarget) {
+                Text(
+                    "Target: ${targetSeconds}s",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 6.dp),
+                )
+            }
             Text("${elapsed}s logged", fontWeight = FontWeight.Bold, color = AppPalette.TextMain, modifier = Modifier.padding(top = 10.dp))
             Spacer(Modifier.height(10.dp))
             if (editing) {
@@ -795,6 +804,15 @@ private fun DurationTimer(
                 },
                 fontSize = 13.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+        if (hasTarget) {
+            Text(
+                "Target: ${targetSeconds}s",
+                fontSize = 13.sp,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 6.dp),
             )
         }
         Button(

--- a/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionScreen.kt
+++ b/android/app/src/main/java/com/tharuka/routines/workout/WorkoutSessionScreen.kt
@@ -661,7 +661,7 @@ private fun RestRing(
  * resetting by hand when the user moves to a different set.
  */
 @Composable
-private fun DurationTimer(
+fun DurationTimer(
     targetSeconds: Int,
     initialSeconds: Int?,
     onLog: (Int) -> Unit,
@@ -670,6 +670,7 @@ private fun DurationTimer(
     var elapsed by remember { mutableStateOf(0) }
     var editing by remember { mutableStateOf(false) }
     var customValue by remember { mutableStateOf("") }
+    var runId by remember { mutableStateOf(0) }
 
     LaunchedEffect(phase, elapsed) {
         if (phase == "running") {
@@ -681,15 +682,19 @@ private fun DurationTimer(
     val hasTarget = targetSeconds > 0
     val overtime = if (hasTarget) maxOf(0, elapsed - targetSeconds) else 0
     val inOvertime = hasTarget && elapsed >= targetSeconds
+    val remaining = if (hasTarget) maxOf(0, targetSeconds - elapsed) else elapsed
     // Fills up toward 1 as elapsed approaches the target (mirroring how the same ring fills as
     // sets complete elsewhere), then just stays full through overtime rather than continuing
-    // past a full circle.
+    // past a full circle. Only used as the static fallback fraction (idle/stopped) now - the
+    // running phase drives the ring via MomentumRing's own animateSeconds/animateKey instead, a
+    // single continuous linear sweep instead of a spring catch-up every second.
     val fraction = if (phase != "idle" && hasTarget) (elapsed.toFloat() / targetSeconds.toFloat()).coerceAtMost(1f) else 0f
 
     fun start() {
         elapsed = 0
         editing = false
         phase = "running"
+        runId += 1
     }
 
     fun stop() {
@@ -704,19 +709,19 @@ private fun DurationTimer(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             MomentumRing(modifier = Modifier.fillMaxWidth().height(230.dp), fraction = fraction, interactive = false) {
-                Text("${elapsed}s", fontSize = 48.sp, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.onBackground)
+                Text(formatHms(elapsed), fontSize = 48.sp, fontWeight = FontWeight.ExtraBold, color = MaterialTheme.colorScheme.onBackground)
                 Text("Logged", fontSize = 13.sp, color = MaterialTheme.colorScheme.onSurfaceVariant)
             }
             if (hasTarget) {
                 Text(
-                    "Target: ${targetSeconds}s",
+                    "Target: ${formatHms(targetSeconds)}",
                     fontSize = 13.sp,
                     fontWeight = FontWeight.SemiBold,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     modifier = Modifier.padding(top = 6.dp),
                 )
             }
-            Text("${elapsed}s logged", fontWeight = FontWeight.Bold, color = AppPalette.TextMain, modifier = Modifier.padding(top = 10.dp))
+            Text("${formatHms(elapsed)} logged", fontWeight = FontWeight.Bold, color = AppPalette.TextMain, modifier = Modifier.padding(top = 10.dp))
             Spacer(Modifier.height(10.dp))
             if (editing) {
                 Row(
@@ -743,7 +748,7 @@ private fun DurationTimer(
                         shape = RoundedCornerShape(999.dp),
                     ) {
                         Text(
-                            if (overtime > 0) "Log full time (${elapsed}s)" else "Log time (${elapsed}s)",
+                            if (overtime > 0) "Log full time (${formatHms(elapsed)})" else "Log time (${formatHms(elapsed)})",
                             fontWeight = FontWeight.Bold,
                         )
                     }
@@ -757,7 +762,7 @@ private fun DurationTimer(
                                 contentColor = AppPalette.Accent,
                             ),
                         ) {
-                            Text("Log target only (${targetSeconds}s)", fontWeight = FontWeight.Bold)
+                            Text("Log target only (${formatHms(targetSeconds)})", fontWeight = FontWeight.Bold)
                         }
                     }
                     // Sharing one row instead of each taking a full stacked row - on a real
@@ -782,12 +787,18 @@ private fun DurationTimer(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        MomentumRing(modifier = Modifier.fillMaxWidth().height(230.dp), fraction = fraction, interactive = false) {
+        MomentumRing(
+            modifier = Modifier.fillMaxWidth().height(230.dp),
+            fraction = fraction,
+            interactive = false,
+            animateSeconds = if (phase == "running" && hasTarget) targetSeconds else null,
+            animateKey = runId,
+        ) {
             Text(
                 text = when {
-                    phase == "idle" -> "${initialSeconds ?: targetSeconds}s"
-                    inOvertime -> "+${overtime}s"
-                    else -> "${elapsed}s"
+                    phase == "idle" -> formatHms(initialSeconds ?: targetSeconds)
+                    inOvertime -> "+${formatHms(overtime)}"
+                    else -> formatHms(remaining)
                 },
                 fontSize = 48.sp,
                 fontWeight = FontWeight.ExtraBold,
@@ -799,7 +810,7 @@ private fun DurationTimer(
                 when {
                     phase == "idle" -> "Ready"
                     inOvertime -> "Overtime"
-                    hasTarget -> "Target"
+                    hasTarget -> "Remaining"
                     else -> "Elapsed"
                 },
                 fontSize = 13.sp,
@@ -808,7 +819,7 @@ private fun DurationTimer(
         }
         if (hasTarget) {
             Text(
-                "Target: ${targetSeconds}s",
+                "Target: ${formatHms(targetSeconds)}",
                 fontSize = 13.sp,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -843,15 +854,33 @@ private fun MomentumRing(
     fraction: Float,
     interactive: Boolean = true,
     onTap: () -> Unit = {},
+    // When set (DurationTimer's running phase only), the ring fills via a single continuous
+    // linear animation spanning `animateSeconds` real seconds, restarted on every `animateKey`
+    // change - the same LinearEasing tween RestRing already uses for its own depleting sweep,
+    // just filling instead. This replaces the spring-driven `fraction` animation below for as
+    // long as it's active: re-deriving `fraction` from `elapsed` once a second and re-triggering
+    // a fresh spring catch-up each time reads as discrete steps, not the continuous sweep a
+    // countdown ring should have.
+    animateSeconds: Int? = null,
+    animateKey: Int = 0,
     centerContent: @Composable () -> Unit,
 ) {
     val targetFraction = fraction.coerceIn(0f, 1f)
     val animatedFraction = remember { Animatable(targetFraction) }
-    LaunchedEffect(targetFraction) {
-        animatedFraction.animateTo(
-            targetFraction,
-            animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow),
-        )
+    if (animateSeconds != null) {
+        LaunchedEffect(animateKey) {
+            animatedFraction.snapTo(0f)
+            if (animateSeconds > 0) {
+                animatedFraction.animateTo(1f, animationSpec = tween(animateSeconds * 1000, easing = LinearEasing))
+            }
+        }
+    } else {
+        LaunchedEffect(targetFraction) {
+            animatedFraction.animateTo(
+                targetFraction,
+                animationSpec = spring(dampingRatio = Spring.DampingRatioMediumBouncy, stiffness = Spring.StiffnessLow),
+            )
+        }
     }
 
     val scale = remember { Animatable(1f) }
@@ -1031,4 +1060,18 @@ private fun WorkoutCompleteScreen(totalCompletedSets: Int, totalPlannedSets: Int
 private fun formatNumber(value: Double): String {
     val rounded = (value * 10).roundToInt() / 10.0
     return if (rounded == rounded.toLong().toDouble()) rounded.toLong().toString() else rounded.toString()
+}
+
+/** Formats whole seconds as M:SS, or H:MM:SS once an hour is involved - mirrors
+ * src/utils/tasks.js's formatHms exactly, for every timer display on this screen and
+ * QuantityTimerScreen's pure-timer flow. */
+fun formatHms(totalSeconds: Int): String {
+    val sign = if (totalSeconds < 0) "-" else ""
+    val s = kotlin.math.abs(totalSeconds)
+    val hours = s / 3600
+    val minutes = (s % 3600) / 60
+    val seconds = s % 60
+    val mm = if (hours > 0) minutes.toString().padStart(2, '0') else minutes.toString()
+    val ss = seconds.toString().padStart(2, '0')
+    return if (hours > 0) "$sign$hours:$mm:$ss" else "$sign$mm:$ss"
 }

--- a/src/App.css
+++ b/src/App.css
@@ -918,6 +918,42 @@
   font-size: 0.9em;
 }
 
+.field-hint {
+  font-size: 0.82em;
+  color: var(--text-soft);
+  margin: -0.4rem 0 0;
+}
+
+.routine-form label.checkbox-field {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.checkbox-field input[type='checkbox'] {
+  width: auto;
+}
+
+.hms-input-row {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 0.3rem;
+}
+
+.hms-part {
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85em;
+  color: var(--text-soft);
+}
+
+.routine-form .hms-part input {
+  width: 3.4rem;
+  text-align: center;
+}
+
 .day-buttons,
 .icon-buttons {
   display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -16,35 +16,50 @@
 
 .app-header {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.5rem;
   padding: 1.4rem 1.2rem 1rem;
 }
 
-.app-logo-badge {
-  width: 34px;
-  height: 34px;
-  min-width: 34px;
+.app-header h1 {
+  flex-shrink: 1;
+  min-width: 0;
+  font-size: 1.2em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Combined selector (not just .app-logo-badge alone) so this reliably beats .icon-badge's own
+   38px sizing regardless of the two rules' order in the stylesheet - same specificity, equal
+   source order otherwise leaves the outcome to whichever rule happens to be declared later. */
+.icon-badge.app-logo-badge {
+  width: 30px;
+  height: 30px;
+  min-width: 30px;
+  flex-shrink: 0;
 }
 
 .app-version-badge {
-  font-size: 0.7rem;
+  flex-shrink: 0;
+  font-size: 0.65rem;
   font-weight: 600;
   color: var(--text-soft);
   background: var(--card);
   border: 1px solid var(--card-border);
   border-radius: 999px;
-  padding: 0.15rem 0.5rem;
+  padding: 0.15rem 0.4rem;
   white-space: nowrap;
 }
 
 .update-check-btn {
   margin-left: auto;
   position: relative;
-  width: 34px;
-  height: 34px;
-  min-width: 34px;
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  min-width: 30px;
   padding: 0;
   border-radius: 999px;
   border: 1px solid var(--card-border);
@@ -66,9 +81,10 @@
 }
 
 .settings-btn {
-  width: 34px;
-  height: 34px;
-  min-width: 34px;
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  min-width: 30px;
   padding: 0;
   border-radius: 999px;
   border: 1px solid var(--card-border);
@@ -82,7 +98,7 @@
 /* Sits after UpdateChecker's own margin-left: auto, so this one shouldn't repeat it - only the
    first flex-pushed item in the header needs to claim the remaining space. */
 .update-check-btn + .settings-btn {
-  margin-left: 0.5rem;
+  margin-left: 0.4rem;
 }
 
 .settings-view {

--- a/src/App.css
+++ b/src/App.css
@@ -187,6 +187,15 @@
   color: var(--bad);
 }
 
+.form-error {
+  color: var(--bad);
+  background: var(--bad-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.8rem;
+  font-size: 0.9em;
+  margin: 0.5rem 0 0;
+}
+
 .auto-backup-list {
   display: flex;
   flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -28,6 +28,17 @@
   min-width: 34px;
 }
 
+.app-version-badge {
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: var(--text-soft);
+  background: var(--card);
+  border: 1px solid var(--card-border);
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  white-space: nowrap;
+}
+
 .update-check-btn {
   margin-left: auto;
   position: relative;
@@ -2304,6 +2315,16 @@
   gap: 0.6rem;
   width: 100%;
   margin-top: 10px;
+}
+
+/* The configured target duration, shown as a plain number alongside the ring's live
+   elapsed/overtime count - the ring's own "Target" hint only labels *what kind* of value is
+   showing, not what the target actually is. */
+.workout-duration-target {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-soft);
+  margin-top: 6px;
 }
 
 /* Reached (or exceeded) the target duration - the same "achievement" hue as streaks/PRs, since

--- a/src/App.css
+++ b/src/App.css
@@ -187,15 +187,6 @@
   color: var(--bad);
 }
 
-.form-error {
-  color: var(--bad);
-  background: var(--bad-soft);
-  border-radius: var(--radius-sm);
-  padding: 0.6rem 0.8rem;
-  font-size: 0.9em;
-  margin: 0.5rem 0 0;
-}
-
 .auto-backup-list {
   display: flex;
   flex-direction: column;
@@ -1007,6 +998,9 @@
 
 .form-error {
   color: var(--bad);
+  background: var(--bad-soft);
+  border-radius: var(--radius-sm);
+  padding: 0.6rem 0.8rem;
   font-size: 0.85em;
   margin: 0;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -386,7 +386,7 @@ function App() {
     <div className="app-shell">
       <header className="app-header">
         <span className="icon-badge app-logo-badge">
-          <Logo size={20} />
+          <Logo size={17} />
         </span>
         <h1>Daily Routines</h1>
         {appVersion && <span className="app-version-badge">v{appVersion}</span>}
@@ -398,7 +398,7 @@ function App() {
           aria-label="Settings"
           title="Settings"
         >
-          <SettingsIcon size={17} />
+          <SettingsIcon size={15} />
         </button>
       </header>
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { App as CapacitorApp } from '@capacitor/app';
 import { Sun, ListTodo, BarChart3, Calendar, Settings as SettingsIcon } from 'lucide-react';
 import './App.css';
 import TodayView from './components/TodayView';
@@ -77,6 +79,7 @@ function App() {
   const [activeSession, setActiveSession] = useState(null);
   const [focusTarget, setFocusTarget] = useState(null);
   const [showSettings, setShowSettings] = useState(false);
+  const [appVersion, setAppVersion] = useState(null);
   const handleLogWorkoutSetRef = useRef(null);
 
   const refreshAll = async () => {
@@ -109,6 +112,16 @@ function App() {
     await syncDynamicNotifications(state.routines, state.taskVersionsMap, state.completions);
     return state;
   };
+
+  // Native-only, like SettingsView's own identical fetch - there's no installed build to report
+  // on web. Surfaced right in the header (not just inside Settings) so which release is running
+  // is visible at a glance, without an extra tap.
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) return;
+    CapacitorApp.getInfo()
+      .then((info) => setAppVersion(info.version))
+      .catch(() => {});
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -376,6 +389,7 @@ function App() {
           <Logo size={20} />
         </span>
         <h1>Daily Routines</h1>
+        {appVersion && <span className="app-version-badge">v{appVersion}</span>}
         <UpdateChecker />
         <button
           type="button"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,10 +11,13 @@ import Logo from './components/Logo';
 import UpdateChecker from './components/UpdateChecker';
 import SettingsView from './components/SettingsView';
 import WorkoutSessionView from './components/WorkoutSessionView';
+import QuantityTimerView from './components/QuantityTimerView';
 import {
   isNativeWorkoutSessionAvailable,
   startNativeWorkoutSession,
   initWorkoutSetListener,
+  startNativeQuantityTimer,
+  initQuantityTimerListener,
 } from './nativeWorkoutSession';
 import {
   initDueReminderActionListener,
@@ -81,6 +84,7 @@ function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [appVersion, setAppVersion] = useState(null);
   const handleLogWorkoutSetRef = useRef(null);
+  const handleLogQuantityTimerRef = useRef(null);
 
   const refreshAll = async () => {
     const [storedRoutines, storedCompletions, versionsMap, workoutLogs] = await Promise.all([
@@ -181,6 +185,14 @@ function App() {
       if (task) await handleLogWorkoutSetRef.current(task, dateKey, exercise, setIndex, values);
     });
 
+    // Fired once when the native "pure timer" screen (a quantity task set up as a timer) logs
+    // its one value - see nativeWorkoutSession.js's startNativeQuantityTimer/QuantityTimerScreen.
+    const quantityTimerListenerPromise = initQuantityTimerListener(async (taskId, dateKey, seconds) => {
+      const state = await refreshAll();
+      const task = findTask(state.routines, taskId);
+      if (task) await handleLogQuantityTimerRef.current(task, dateKey, seconds);
+    });
+
     // Fired roughly every 15 minutes by the native background-sync foreground service (see
     // BackgroundSyncService.kt) as long as the app process is alive, foreground or backgrounded
     // - keeps digest/summary/streak-risk content fresh without requiring the user to reopen the
@@ -195,6 +207,7 @@ function App() {
       dueReminderListenerPromise?.then((handle) => handle.remove());
       notificationTapListenerPromise?.then((handle) => handle.remove());
       workoutListenerPromise?.then((handle) => handle.remove());
+      quantityTimerListenerPromise?.then((handle) => handle.remove());
       backgroundSyncListenerPromise?.then((handle) => handle.remove());
     };
   }, []);
@@ -331,6 +344,20 @@ function App() {
     setActiveSession({ task, routine, dateKey });
   };
 
+  // A quantity task set up as a timer (RoutineForm's "Input as: Timer" mode) launches the same
+  // native foreground-service-backed screen a workout session does (see
+  // nativeWorkoutSession.js's startNativeQuantityTimer) - deliberately not a plain in-WebView JS
+  // timer, so a long run survives backgrounding/screen-lock. `activeSession` is reused as-is for
+  // the web/dev fallback; the render branch below picks WorkoutSessionView vs QuantityTimerView
+  // by completionType.
+  const handleStartQuantityTimer = (task, routine, dateKey) => {
+    if (isNativeWorkoutSessionAvailable()) {
+      startNativeQuantityTimer(task, dateKey);
+      return;
+    }
+    setActiveSession({ task, routine, dateKey });
+  };
+
   const handleCloseSession = () => {
     setActiveSession(null);
   };
@@ -351,8 +378,41 @@ function App() {
   };
   handleLogWorkoutSetRef.current = handleLogWorkoutSet;
 
+  // The one value a quantity-as-timer session logs - additive (via handleAddQuantity), matching
+  // the plain quick-add buttons' own semantics, since a timer can reasonably be run more than
+  // once in a day (e.g. two separate meditation sessions) and each run should add to the day's
+  // total rather than overwrite it. "New best" for the auto-update-target opt-in is judged
+  // against this one run's own seconds, not the day's accumulated total - a single 65s hold
+  // against a 60s target is a new best regardless of what else was logged that day.
+  const handleLogQuantityTimer = async (task, dateKey, seconds) => {
+    await handleAddQuantity(task, seconds, dateKey);
+    if (task.autoUpdateTarget && seconds > (task.target || 0)) {
+      await upsertTask({ ...task, target: seconds });
+      const state = await refreshAll();
+      const savedRoutine = state.routines.find((r) => r.id === task.routineId);
+      const savedTask = savedRoutine?.tasks.find((t) => t.id === task.id);
+      if (savedTask) await scheduleTaskNotifications(savedTask, savedRoutine, state.completions);
+    }
+  };
+  handleLogQuantityTimerRef.current = handleLogQuantityTimer;
+
   if (loading) {
     return <div className="app-shell loading">Loading…</div>;
+  }
+
+  if (activeSession && activeSession.task.completionType === 'quantity') {
+    return (
+      <div className="app-shell">
+        <QuantityTimerView
+          task={activeSession.task}
+          onLog={async (seconds) => {
+            await handleLogQuantityTimer(activeSession.task, activeSession.dateKey, seconds);
+            handleCloseSession();
+          }}
+          onClose={handleCloseSession}
+        />
+      </div>
+    );
   }
 
   if (activeSession) {
@@ -412,6 +472,7 @@ function App() {
             onAddQuantity={handleAddQuantity}
             onSetQuantity={handleSetQuantity}
             onStartWorkout={handleStartWorkout}
+            onStartQuantityTimer={handleStartQuantityTimer}
             focusTaskId={focusTarget?.taskId}
             focusRoutineId={focusTarget?.routineId}
             onFocusHandled={() => setFocusTarget(null)}

--- a/src/components/DurationTimer.jsx
+++ b/src/components/DurationTimer.jsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import { formatHms } from '../utils/tasks';
+
+export const RING_RADIUS = 80;
+export const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
+
+/**
+ * The dominant, full-screen tap target for logging a set - the same circle shown whenever a
+ * task/exercise is actively being worked. Two fill modes:
+ * - Plain `fraction` (0-1): fills in step by step as `fraction` grows (a spring-like transition
+ *   already defined on `.workout-ring-fill`) - used for the reps-tap flow (interactive) and
+ *   DurationTimer's own idle/stopped states (static).
+ * - `animateSeconds` (+ `animateKey` to restart it): fills smoothly via a single CSS transition
+ *   spanning that many real wall-clock seconds, the same two-frame trick RestRing uses for its
+ *   own depleting sweep, just filling instead - decoupled from React re-renders entirely, so it
+ *   reads as continuous motion rather than the once-a-second steps a JS-driven `fraction` update
+ *   would produce. Used by DurationTimer while actively running.
+ */
+export function MomentumRing({
+  fraction,
+  interactive,
+  onClick,
+  pulseKey = 0,
+  hint,
+  children,
+  animateSeconds,
+  animateKey = 0,
+}) {
+  const [animatedIn, setAnimatedIn] = useState(false);
+
+  useEffect(() => {
+    if (animateSeconds == null) return undefined;
+    setAnimatedIn(false);
+    const raf = requestAnimationFrame(() => setAnimatedIn(true));
+    return () => cancelAnimationFrame(raf);
+  }, [animateSeconds, animateKey]);
+
+  const ringStyle =
+    animateSeconds != null
+      ? {
+          strokeDasharray: RING_CIRCUMFERENCE,
+          strokeDashoffset: animatedIn ? 0 : RING_CIRCUMFERENCE,
+          transition: animatedIn ? `stroke-dashoffset ${animateSeconds}s linear` : 'none',
+        }
+      : {
+          strokeDasharray: RING_CIRCUMFERENCE,
+          strokeDashoffset: RING_CIRCUMFERENCE - Math.max(0, Math.min(1, fraction)) * RING_CIRCUMFERENCE,
+        };
+
+  return (
+    <button
+      type="button"
+      className={`workout-ring-tap ${interactive ? '' : 'non-interactive'}`}
+      onClick={interactive ? onClick : undefined}
+      disabled={!interactive}
+      aria-label={hint}
+    >
+      <span key={`pulse-${pulseKey}`} className="workout-ring-pulse" />
+      <svg className="workout-ring-svg" viewBox="0 0 180 180">
+        <circle className="workout-ring-track" cx="90" cy="90" r={RING_RADIUS} />
+        <circle className="workout-ring-fill" cx="90" cy="90" r={RING_RADIUS} style={ringStyle} />
+      </svg>
+      <span key={`center-${pulseKey}`} className="workout-ring-center">
+        {children}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * A live, auto-continuing timer for a duration-based target - shared by the workout session's
+ * duration exercises and the quantity-as-timer task type (the latter renders this with no
+ * surrounding weight/reps chrome at all, since this component never touched those fields to
+ * begin with). Counts DOWN from the target by default (remaining = target - elapsed) - matching
+ * a normal kitchen-timer expectation - then keeps counting up into overtime automatically once
+ * it hits zero: there is deliberately no "continue" button. The only manual actions are Stop
+ * (moves to a review step letting the user log the full time, the target only, or a typed custom
+ * value) and, from that review step, "Start again" (an explicit redo that discards this attempt
+ * with nothing logged, for a mis-timed or aborted run). The parent remounts this via a `key` when
+ * switching between independent targets (e.g. exerciseIndex/setIndex), so its own phase/elapsed
+ * state never needs resetting by hand.
+ *
+ * The ring fills smoothly (see MomentumRing's animateSeconds) for the entire running phase -
+ * once elapsed reaches the target, the CSS transition has already finished on its own (same real
+ * clock), so the ring simply stays full through overtime with no extra logic needed.
+ */
+export function DurationTimer({ targetSeconds, initialSeconds, onLog }) {
+  const [phase, setPhase] = useState('idle'); // 'idle' | 'running' | 'stopped'
+  const [elapsed, setElapsed] = useState(0);
+  const [editing, setEditing] = useState(false);
+  const [customValue, setCustomValue] = useState('');
+  const [runId, setRunId] = useState(0);
+
+  useEffect(() => {
+    if (phase !== 'running') return undefined;
+    const t = setInterval(() => setElapsed((e) => e + 1), 1000);
+    return () => clearInterval(t);
+  }, [phase]);
+
+  const hasTarget = targetSeconds > 0;
+  const overtime = hasTarget ? Math.max(0, elapsed - targetSeconds) : 0;
+  const inOvertime = hasTarget && elapsed >= targetSeconds;
+  const remaining = hasTarget ? Math.max(0, targetSeconds - elapsed) : elapsed;
+  const fraction = phase === 'idle' ? 0 : hasTarget ? Math.min(1, elapsed / targetSeconds) : 0;
+
+  const start = () => {
+    setElapsed(0);
+    setEditing(false);
+    setPhase('running');
+    setRunId((n) => n + 1);
+  };
+
+  const stop = () => {
+    setPhase('stopped');
+    setEditing(false);
+    setCustomValue(String(elapsed));
+  };
+
+  if (phase === 'stopped') {
+    return (
+      <>
+        <MomentumRing fraction={fraction} interactive={false} hint="Duration set progress">
+          <span className="workout-ring-num">{formatHms(elapsed)}</span>
+          <span className="workout-ring-hint">Logged</span>
+        </MomentumRing>
+        <div className="workout-duration-review">
+          {hasTarget && <span className="workout-duration-target">Target: {formatHms(targetSeconds)}</span>}
+          <span className="workout-duration-review-total">{formatHms(elapsed)} logged</span>
+          {editing ? (
+            <div className="workout-duration-review-edit">
+              <input
+                type="number"
+                min="0"
+                autoFocus
+                value={customValue}
+                onChange={(e) => setCustomValue(e.target.value)}
+              />
+              <button
+                type="button"
+                className="workout-duration-btn primary"
+                onClick={() => onLog(customValue === '' ? 0 : Number(customValue))}
+              >
+                Confirm
+              </button>
+            </div>
+          ) : (
+            <div className="workout-duration-review-actions">
+              <button type="button" className="workout-duration-btn primary" onClick={() => onLog(elapsed)}>
+                {overtime > 0 ? `Log full time (${formatHms(elapsed)})` : `Log time (${formatHms(elapsed)})`}
+              </button>
+              {overtime > 0 && (
+                <button type="button" className="workout-duration-btn" onClick={() => onLog(targetSeconds)}>
+                  Log target only ({formatHms(targetSeconds)})
+                </button>
+              )}
+              <div className="workout-duration-review-secondary">
+                <button type="button" className="workout-duration-btn ghost" onClick={() => setEditing(true)}>
+                  Edit custom time
+                </button>
+                <button type="button" className="workout-duration-btn ghost" onClick={start}>
+                  Start again
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <MomentumRing
+        fraction={fraction}
+        interactive={false}
+        hint="Duration timer"
+        animateSeconds={phase === 'running' && hasTarget ? targetSeconds : undefined}
+        animateKey={runId}
+      >
+        <span className={`workout-ring-num ${inOvertime ? 'overtime' : ''}`}>
+          {phase === 'idle'
+            ? formatHms(initialSeconds ?? targetSeconds ?? 0)
+            : inOvertime
+              ? `+${formatHms(overtime)}`
+              : formatHms(remaining)}
+        </span>
+        <span className="workout-ring-hint">
+          {phase === 'idle' ? 'Ready' : inOvertime ? 'Overtime' : hasTarget ? 'Remaining' : 'Elapsed'}
+        </span>
+      </MomentumRing>
+      {hasTarget && <div className="workout-duration-target">Target: {formatHms(targetSeconds)}</div>}
+      <div className="workout-duration-timer">
+        {phase === 'idle' ? (
+          <button type="button" className="workout-duration-btn primary" onClick={start}>
+            Start
+          </button>
+        ) : (
+          <button type="button" className="workout-duration-btn stop" onClick={stop}>
+            Stop
+          </button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/components/QuantityTimerView.jsx
+++ b/src/components/QuantityTimerView.jsx
@@ -1,0 +1,27 @@
+import { DurationTimer } from './DurationTimer';
+
+/**
+ * The web/dev-loop counterpart of the native "pure timer" flow (QuantityTimerScreen.kt) - a
+ * quantity task set up as a timer (RoutineForm's "Input as: Timer" mode), reusing the exact same
+ * DurationTimer widget the workout session's duration exercises use, with none of the
+ * weight/reps/exercise-nav chrome around it. Only ever reached via `npm run dev` in a browser,
+ * same as WorkoutSessionView - on a real device this task type launches the native screen instead
+ * (see nativeWorkoutSession.js's startNativeQuantityTimer), specifically so a long-running timer
+ * survives backgrounding via a real foreground service rather than a WebView setInterval that
+ * Android would throttle/suspend.
+ */
+export default function QuantityTimerView({ task, onLog, onClose }) {
+  return (
+    <div className="workout-session">
+      <div className="workout-session-header">
+        <span className="workout-session-title">{task.title}</span>
+        <button type="button" className="workout-session-close" onClick={onClose} aria-label="Close">
+          <span aria-hidden="true">✕</span>
+        </button>
+      </div>
+      <div className="workout-set-panel">
+        <DurationTimer targetSeconds={Number(task.target) || 0} initialSeconds={null} onLog={onLog} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/RoutineForm.jsx
+++ b/src/components/RoutineForm.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { List, X } from 'lucide-react';
-import { parseQuickAddText, MAX_EXTRA_REMINDERS } from '../utils/tasks';
+import { parseQuickAddText, MAX_EXTRA_REMINDERS, formatHms, hmsToSeconds, secondsToHms } from '../utils/tasks';
 import { DAY_LABELS } from '../utils/date';
 import { ICON_OPTIONS, suggestIconId } from '../utils/icons';
 import { generateId } from '../utils/id';
@@ -23,6 +23,8 @@ function makeTask(days) {
     target: null,
     unit: null,
     quickAdd: null,
+    quantityMode: 'number',
+    autoUpdateTarget: false,
     exercises: [],
     active: true,
     createdAt: new Date().toISOString(),
@@ -69,6 +71,64 @@ function QuickAddInput({ task, onChange }) {
         onChange={(e) => handleChange(e.target.value)}
       />
     </label>
+  );
+}
+
+/**
+ * Every timer-related target in the app (exercise duration, quantity-as-timer) is set up through
+ * this shared hours/minutes/seconds triplet instead of a single raw-seconds field - much easier
+ * to enter a real-world duration like "10 minutes" than to do the mental math to 600. Storage/
+ * versioning is untouched by this: task.target and exercise.targetDurationSeconds still hold a
+ * single total-seconds number either way (see utils/tasks.js's hmsToSeconds/secondsToHms), so no
+ * schema change was needed to support this input style.
+ */
+function DurationHMSInput({ totalSeconds, onChange, label }) {
+  const { hours, minutes, seconds } = secondsToHms(totalSeconds);
+
+  const update = (patch) => {
+    const next = { hours, minutes, seconds, ...patch };
+    const combined = hmsToSeconds(next.hours, next.minutes, next.seconds);
+    onChange(combined || null);
+  };
+
+  return (
+    <div className="hms-input">
+      {label && <span className="field-label">{label}</span>}
+      <div className="hms-input-row">
+        <label className="hms-part">
+          <input
+            type="number"
+            min="0"
+            placeholder="0"
+            value={hours || ''}
+            onChange={(e) => update({ hours: e.target.value ? Number(e.target.value) : 0 })}
+          />
+          <span>h</span>
+        </label>
+        <label className="hms-part">
+          <input
+            type="number"
+            min="0"
+            max="59"
+            placeholder="0"
+            value={minutes || ''}
+            onChange={(e) => update({ minutes: e.target.value ? Number(e.target.value) : 0 })}
+          />
+          <span>m</span>
+        </label>
+        <label className="hms-part">
+          <input
+            type="number"
+            min="0"
+            max="59"
+            placeholder="0"
+            value={seconds || ''}
+            onChange={(e) => update({ seconds: e.target.value ? Number(e.target.value) : 0 })}
+          />
+          <span>s</span>
+        </label>
+      </div>
+    </div>
   );
 }
 
@@ -317,19 +377,11 @@ function ExerciseListEditor({ task, onChange, exerciseNames }) {
                 />
               </label>
               {ex.unit === 'seconds' ? (
-                <label>
-                  Duration/set (sec)
-                  <input
-                    type="number"
-                    min="1"
-                    value={ex.targetDurationSeconds ?? ''}
-                    onChange={(e) =>
-                      updateExercise(ex.id, {
-                        targetDurationSeconds: e.target.value ? Number(e.target.value) : null,
-                      })
-                    }
-                  />
-                </label>
+                <DurationHMSInput
+                  label="Duration/set"
+                  totalSeconds={ex.targetDurationSeconds}
+                  onChange={(secs) => updateExercise(ex.id, { targetDurationSeconds: secs })}
+                />
               ) : (
                 <label>
                   Reps/set
@@ -430,7 +482,14 @@ function TaskFields({ task, onChange, showTitle, exerciseNames }) {
           <button
             type="button"
             className={task.completionType === 'quantity' ? 'active' : ''}
-            onClick={() => onChange({ ...task, completionType: 'quantity', target: task.target ?? 10 })}
+            onClick={() =>
+              onChange({
+                ...task,
+                completionType: 'quantity',
+                target: task.target ?? 10,
+                quantityMode: task.quantityMode || 'number',
+              })
+            }
           >
             Quantity target
           </button>
@@ -454,27 +513,70 @@ function TaskFields({ task, onChange, showTitle, exerciseNames }) {
       </div>
       {task.completionType === 'quantity' && (
         <>
-          <div className="inline-fields">
-            <label>
-              Target
-              <input
-                type="number"
-                min="1"
-                value={task.target ?? ''}
-                onChange={(e) => onChange({ ...task, target: e.target.value ? Number(e.target.value) : null })}
-              />
-            </label>
-            <label>
-              Unit (optional)
-              <input
-                type="text"
-                placeholder="reps, pages…"
-                value={task.unit ?? ''}
-                onChange={(e) => onChange({ ...task, unit: e.target.value })}
-              />
-            </label>
+          <div>
+            <span className="field-label">Input as</span>
+            <div className="type-toggle">
+              <button
+                type="button"
+                className={task.quantityMode !== 'timer' ? 'active' : ''}
+                onClick={() => onChange({ ...task, quantityMode: 'number', target: null })}
+              >
+                Number
+              </button>
+              <button
+                type="button"
+                className={task.quantityMode === 'timer' ? 'active' : ''}
+                onClick={() => onChange({ ...task, quantityMode: 'timer', target: null, unit: null, quickAdd: null })}
+              >
+                Timer
+              </button>
+            </div>
           </div>
-          <QuickAddInput task={task} onChange={onChange} />
+          {task.quantityMode === 'timer' ? (
+            <>
+              <DurationHMSInput
+                label="Target duration"
+                totalSeconds={task.target}
+                onChange={(secs) => onChange({ ...task, target: secs })}
+              />
+              <label className="checkbox-field">
+                <input
+                  type="checkbox"
+                  checked={Boolean(task.autoUpdateTarget)}
+                  onChange={(e) => onChange({ ...task, autoUpdateTarget: e.target.checked })}
+                />
+                Auto-update target to new best
+              </label>
+              <p className="field-hint">
+                When on, logging a time longer than the current target raises the target to that
+                new best for next time.
+              </p>
+            </>
+          ) : (
+            <>
+              <div className="inline-fields">
+                <label>
+                  Target
+                  <input
+                    type="number"
+                    min="1"
+                    value={task.target ?? ''}
+                    onChange={(e) => onChange({ ...task, target: e.target.value ? Number(e.target.value) : null })}
+                  />
+                </label>
+                <label>
+                  Unit (optional)
+                  <input
+                    type="text"
+                    placeholder="reps, pages…"
+                    value={task.unit ?? ''}
+                    onChange={(e) => onChange({ ...task, unit: e.target.value })}
+                  />
+                </label>
+              </div>
+              <QuickAddInput task={task} onChange={onChange} />
+            </>
+          )}
         </>
       )}
       {task.completionType === 'workout' && (
@@ -646,7 +748,9 @@ export default function RoutineForm({ initial, onSave, onCancel }) {
                     <div className="meta">
                       {task.time} · {task.days.length === 7 ? 'Every day' : `${task.days.length}/week`} ·{' '}
                       {task.completionType === 'quantity' &&
-                        `Target ${task.target ?? '?'} ${task.unit || ''}`}
+                        (task.quantityMode === 'timer'
+                          ? `Target ${task.target ? formatHms(task.target) : '?'}`
+                          : `Target ${task.target ?? '?'} ${task.unit || ''}`)}
                       {task.completionType === 'workout' &&
                         `${task.exercises?.length ?? 0} exercise${task.exercises?.length === 1 ? '' : 's'}`}
                       {task.completionType === 'boolean' && 'Yes/No'}

--- a/src/components/RoutineForm.jsx
+++ b/src/components/RoutineForm.jsx
@@ -648,13 +648,22 @@ export default function RoutineForm({ initial, onSave, onCancel }) {
     if (editingTaskId === taskId) setEditingTaskId(null);
   };
 
-  const hasUnnamedTask = !isSimple && tasks.some((t) => !t.title.trim());
-  const hasTaskWithNoDays = tasks.some((t) => t.days.length === 0);
-  const hasInvalidWorkout = tasks.some(
+  // "Task N" (1-indexed position, not the task's own possibly-blank title) so a multi-task
+  // routine's validation errors below say exactly which task needs attention, instead of a
+  // single generic message that gives no clue which of several tasks (especially a newly-added
+  // one still mid-setup, like a quantity task just switched to Timer mode) is the problem.
+  const taskLabel = (t) => t.title.trim() || `Task ${tasks.indexOf(t) + 1}`;
+
+  const unnamedTasks = isSimple ? [] : tasks.filter((t) => !t.title.trim());
+  const hasUnnamedTask = unnamedTasks.length > 0;
+  const noDaysTasks = tasks.filter((t) => t.days.length === 0);
+  const hasTaskWithNoDays = noDaysTasks.length > 0;
+  const invalidWorkoutTasks = tasks.filter(
     (t) =>
       t.completionType === 'workout' &&
       (!t.exercises?.length || t.exercises.some((ex) => !ex.name.trim()))
   );
+  const hasInvalidWorkout = invalidWorkoutTasks.length > 0;
   const invalidTask = hasUnnamedTask || hasTaskWithNoDays || hasInvalidWorkout;
 
   const handleSubmit = (e) => {
@@ -780,10 +789,30 @@ export default function RoutineForm({ initial, onSave, onCancel }) {
         </div>
       )}
 
-      {hasUnnamedTask && <p className="form-error">Every task needs a name.</p>}
-      {hasTaskWithNoDays && <p className="form-error">Every task needs at least one day selected.</p>}
+      {hasUnnamedTask && (
+        <p className="form-error">
+          {unnamedTasks.length === 1
+            ? `${taskLabel(unnamedTasks[0])} needs a name.`
+            : `${unnamedTasks.map(taskLabel).join(', ')} need a name.`}
+        </p>
+      )}
+      {hasTaskWithNoDays && (
+        <p className="form-error">
+          {isSimple
+            ? 'This task needs at least one day selected.'
+            : noDaysTasks.length === 1
+              ? `${taskLabel(noDaysTasks[0])} needs at least one day selected.`
+              : `${noDaysTasks.map(taskLabel).join(', ')} need at least one day selected.`}
+        </p>
+      )}
       {hasInvalidWorkout && (
-        <p className="form-error">Every workout task needs at least one named exercise.</p>
+        <p className="form-error">
+          {isSimple
+            ? 'Every workout task needs at least one named exercise.'
+            : invalidWorkoutTasks.length === 1
+              ? `${taskLabel(invalidWorkoutTasks[0])} needs at least one named exercise.`
+              : `${invalidWorkoutTasks.map(taskLabel).join(', ')} need at least one named exercise.`}
+        </p>
       )}
 
       <label>

--- a/src/components/RoutineForm.jsx
+++ b/src/components/RoutineForm.jsx
@@ -535,7 +535,7 @@ function TaskFields({ task, onChange, showTitle, exerciseNames }) {
           {task.quantityMode === 'timer' ? (
             <>
               <DurationHMSInput
-                label="Target duration"
+                label={task.autoUpdateTarget ? 'Target duration (your current best)' : 'Target duration'}
                 totalSeconds={task.target}
                 onChange={(secs) => onChange({ ...task, target: secs })}
               />
@@ -549,7 +549,9 @@ function TaskFields({ task, onChange, showTitle, exerciseNames }) {
               </label>
               <p className="field-hint">
                 When on, logging a time longer than the current target raises the target to that
-                new best for next time.
+                new best for next time. The field above is always editable by hand too - lower it
+                anytime (a bad session inflated it, you're deloading, etc.) and the next real best
+                will raise it again from there.
               </p>
             </>
           ) : (

--- a/src/components/RoutinesView.jsx
+++ b/src/components/RoutinesView.jsx
@@ -17,11 +17,13 @@ export default function RoutinesView({
   const [showForm, setShowForm] = useState(false);
   const [editing, setEditing] = useState(null);
   const [showArchived, setShowArchived] = useState(false);
+  const [saveError, setSaveError] = useState('');
 
   const activeRoutines = routines.filter((r) => !r.archived);
   const archivedRoutines = routines.filter((r) => r.archived);
 
   const startEdit = (routine) => {
+    setSaveError('');
     setEditing(routine);
     setShowForm(true);
   };
@@ -29,11 +31,23 @@ export default function RoutinesView({
   const closeForm = () => {
     setShowForm(false);
     setEditing(null);
+    setSaveError('');
   };
 
+  // Previously any error here (a native SQLite failure, for instance) just silently left the
+  // form open with no feedback at all - the save promise rejected and closeForm() below it never
+  // ran, but nothing ever surfaced why. Catching and showing the real message turns "Save does
+  // nothing" into an actual diagnosable error, and lets the user retry without losing their
+  // in-progress form input (the form deliberately stays open on failure, same as before).
   const handleSave = async (payload) => {
-    await onSaveRoutine(payload);
-    closeForm();
+    setSaveError('');
+    try {
+      await onSaveRoutine(payload);
+      closeForm();
+    } catch (err) {
+      console.warn('Failed to save routine', err);
+      setSaveError(err?.message || 'Something went wrong saving this routine. Please try again.');
+    }
   };
 
   if (showArchived) {
@@ -82,7 +96,13 @@ export default function RoutinesView({
     <div className="routines-view">
       <div className="routines-view-header">
         {!showForm && (
-          <button className="add-btn" onClick={() => setShowForm(true)}>
+          <button
+            className="add-btn"
+            onClick={() => {
+              setSaveError('');
+              setShowForm(true);
+            }}
+          >
             + Add routine
           </button>
         )}
@@ -91,7 +111,12 @@ export default function RoutinesView({
         </button>
       </div>
 
-      {showForm && <RoutineForm initial={editing} onSave={handleSave} onCancel={closeForm} />}
+      {showForm && (
+        <>
+          {saveError && <p className="form-error">{saveError}</p>}
+          <RoutineForm initial={editing} onSave={handleSave} onCancel={closeForm} />
+        </>
+      )}
 
       {activeRoutines.length === 0 && !showForm && (
         <p className="empty-state">No routines yet. Add your first one above.</p>

--- a/src/components/TodayView.jsx
+++ b/src/components/TodayView.jsx
@@ -5,7 +5,7 @@ import { getRoutineFraction, getTaskFraction, dateToKey, todayKey, startOfDay, c
 // Below this, a streak badge reads as noise rather than a meaningful "you're on a roll" signal.
 const STREAK_BADGE_MIN = 3;
 import { getRoutineIcon } from '../utils/icons';
-import { quickAddAmountsFor } from '../utils/tasks';
+import { quickAddAmountsFor, formatHms } from '../utils/tasks';
 
 function isTaskDueOn(task, taskVersionsMap, date) {
   const versions = taskVersionsMap[task.id];
@@ -106,12 +106,25 @@ function StreakBadge({ streak }) {
   );
 }
 
-function QuantityControl({ task, completions, dateKey, onAddQuantity, onSetQuantity, now, showCountdown, routineStreak }) {
+function QuantityControl({
+  task,
+  routine,
+  completions,
+  dateKey,
+  onAddQuantity,
+  onSetQuantity,
+  onStartQuantityTimer,
+  now,
+  showCountdown,
+  isToday,
+  routineStreak,
+}) {
   const actual = completions[task.id]?.[dateKey] || 0;
   const target = task.target || 0;
   const pct = target ? Math.min(100, Math.round((actual / target) * 100)) : 0;
   const isComplete = target > 0 && actual >= target;
   const isPartial = actual > 0 && !isComplete;
+  const isTimer = task.quantityMode === 'timer';
   const quickAmounts = quickAddAmountsFor(task);
 
   return (
@@ -122,7 +135,7 @@ function QuantityControl({ task, completions, dateKey, onAddQuantity, onSetQuant
           <StreakBadge streak={routineStreak} />
         </span>
         <span className={`qty-value ${isComplete ? 'complete' : isPartial ? 'partial' : ''}`}>
-          {actual} / {target} {task.unit || ''}
+          {isTimer ? `${formatHms(actual)} / ${formatHms(target)}` : `${actual} / ${target} ${task.unit || ''}`}
         </span>
       </div>
       <CountdownLabel
@@ -136,23 +149,37 @@ function QuantityControl({ task, completions, dateKey, onAddQuantity, onSetQuant
         <div className={`qty-fill ${isPartial ? 'partial' : ''}`} style={{ width: `${pct}%` }} />
       </div>
       <div className="qty-actions">
-        {quickAmounts.map((amount) => (
-          <button key={amount} className="qty-btn primary" onClick={() => onAddQuantity(task, amount, dateKey)}>
-            + {amount}
+        {isTimer ? (
+          <button
+            type="button"
+            className="qty-btn primary"
+            disabled={!isToday}
+            onClick={() => onStartQuantityTimer(task, routine, dateKey)}
+          >
+            Start timer
           </button>
-        ))}
-        <button
-          className="qty-btn"
-          onClick={() => {
-            const input = window.prompt(`Set ${task.title} total for this day:`, String(actual));
-            if (input === null) return;
-            const parsed = Number(input);
-            if (!Number.isNaN(parsed) && parsed >= 0) onSetQuantity(task, parsed, dateKey);
-          }}
-        >
-          Custom…
-        </button>
+        ) : (
+          <>
+            {quickAmounts.map((amount) => (
+              <button key={amount} className="qty-btn primary" onClick={() => onAddQuantity(task, amount, dateKey)}>
+                + {amount}
+              </button>
+            ))}
+            <button
+              className="qty-btn"
+              onClick={() => {
+                const input = window.prompt(`Set ${task.title} total for this day:`, String(actual));
+                if (input === null) return;
+                const parsed = Number(input);
+                if (!Number.isNaN(parsed) && parsed >= 0) onSetQuantity(task, parsed, dateKey);
+              }}
+            >
+              Custom…
+            </button>
+          </>
+        )}
         {isPartial && <span className="badge-partial">Partial</span>}
+        {isTimer && !isToday && <span className="badge-partial">Today only</span>}
       </div>
     </div>
   );
@@ -202,6 +229,7 @@ export default function TodayView({
   onAddQuantity,
   onSetQuantity,
   onStartWorkout,
+  onStartQuantityTimer,
   focusTaskId,
   focusRoutineId,
   onFocusHandled,
@@ -317,12 +345,15 @@ export default function TodayView({
                     </span>
                     <QuantityControl
                       task={task}
+                      routine={routine}
                       completions={completions}
                       dateKey={dateKey}
                       onAddQuantity={onAddQuantity}
                       onSetQuantity={onSetQuantity}
+                      onStartQuantityTimer={onStartQuantityTimer}
                       now={now}
                       showCountdown={isToday}
+                      isToday={isToday}
                       routineStreak={routineStreak}
                     />
                   </div>
@@ -414,12 +445,15 @@ export default function TodayView({
                         <li className="task-row" key={task.id} id={`today-task-${task.id}`} style={{ alignItems: 'flex-start' }}>
                           <QuantityControl
                             task={task}
+                            routine={routine}
                             completions={completions}
                             dateKey={dateKey}
                             onAddQuantity={onAddQuantity}
                             onSetQuantity={onSetQuantity}
+                            onStartQuantityTimer={onStartQuantityTimer}
                             now={now}
                             showCountdown={isToday}
+                            isToday={isToday}
                           />
                         </li>
                       );

--- a/src/components/UpdateChecker.jsx
+++ b/src/components/UpdateChecker.jsx
@@ -89,7 +89,7 @@ export default function UpdateChecker() {
         aria-label="Check for updates"
         title="Check for updates"
       >
-        <DownloadCloud size={17} className={status === 'checking' || status === 'downloading' ? 'spin' : ''} />
+        <DownloadCloud size={15} className={status === 'checking' || status === 'downloading' ? 'spin' : ''} />
         {status === 'ready' && <span className="update-dot" />}
       </button>
 

--- a/src/components/WorkoutSessionView.jsx
+++ b/src/components/WorkoutSessionView.jsx
@@ -157,6 +157,7 @@ function DurationTimer({ targetSeconds, initialSeconds, onLog }) {
           <span className="workout-ring-hint">Logged</span>
         </MomentumRing>
         <div className="workout-duration-review">
+          {hasTarget && <span className="workout-duration-target">Target: {targetSeconds}s</span>}
           <span className="workout-duration-review-total">{elapsed}s logged</span>
           {editing ? (
             <div className="workout-duration-review-edit">
@@ -214,6 +215,7 @@ function DurationTimer({ targetSeconds, initialSeconds, onLog }) {
           {phase === 'idle' ? 'Ready' : inOvertime ? 'Overtime' : hasTarget ? 'Target' : 'Elapsed'}
         </span>
       </MomentumRing>
+      {hasTarget && <div className="workout-duration-target">Target: {targetSeconds}s</div>}
       <div className="workout-duration-timer">
         {phase === 'idle' ? (
           <button type="button" className="workout-duration-btn primary" onClick={start}>

--- a/src/components/WorkoutSessionView.jsx
+++ b/src/components/WorkoutSessionView.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { ChevronLeft, ChevronRight, Check } from 'lucide-react';
 import { getExercisePR, getExerciseVolume, getLastUsedWeight, kgToLb, lbToKg } from '../utils/workouts';
+import { MomentumRing, DurationTimer } from './DurationTimer';
 
 /** "60" for a whole number, "62.5" otherwise. */
 function formatNumber(value) {
@@ -22,9 +23,6 @@ function findNextPosition(exercises, logsForDate) {
   }
   return null;
 }
-
-const RING_RADIUS = 80;
-const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS;
 
 const REST_RING_RADIUS = 70;
 const REST_RING_CIRCUMFERENCE = 2 * Math.PI * REST_RING_RADIUS;
@@ -67,167 +65,6 @@ function RestRing({ totalSeconds, resetKey }) {
         onTransitionEnd={() => setJustFinished(true)}
       />
     </svg>
-  );
-}
-
-/**
- * The dominant, full-screen tap target for logging a set - the same circle shown whenever a
- * task/exercise is actively being worked, filling in step by step as `fraction` grows (a spring-
- * like transition already defined on `.workout-ring-fill`, reused as-is). Shared between the
- * plain reps-tap flow (interactive, fills as sets complete) and DurationTimer below
- * (non-interactive, fills as time elapses) - both draw from the identical SVG/CSS, not two
- * look-alike rings, so "the same circle" is literal, not just visually similar.
- */
-function MomentumRing({ fraction, interactive, onClick, pulseKey = 0, hint, children }) {
-  const offset = RING_CIRCUMFERENCE - Math.max(0, Math.min(1, fraction)) * RING_CIRCUMFERENCE;
-  return (
-    <button
-      type="button"
-      className={`workout-ring-tap ${interactive ? '' : 'non-interactive'}`}
-      onClick={interactive ? onClick : undefined}
-      disabled={!interactive}
-      aria-label={hint}
-    >
-      <span key={`pulse-${pulseKey}`} className="workout-ring-pulse" />
-      <svg className="workout-ring-svg" viewBox="0 0 180 180">
-        <circle className="workout-ring-track" cx="90" cy="90" r={RING_RADIUS} />
-        <circle
-          className="workout-ring-fill"
-          cx="90"
-          cy="90"
-          r={RING_RADIUS}
-          style={{ strokeDasharray: RING_CIRCUMFERENCE, strokeDashoffset: offset }}
-        />
-      </svg>
-      <span key={`center-${pulseKey}`} className="workout-ring-center">
-        {children}
-      </span>
-    </button>
-  );
-}
-
-/**
- * A live, auto-continuing timer for a duration-based set. Counts down from the exercise's
- * target duration - shown in the same MomentumRing every other set type uses, filling up as
- * elapsed time approaches the target rather than a separate depleting ring - then keeps counting
- * up into overtime automatically once it reaches zero: there is deliberately no "continue"
- * button. The only manual actions are Stop (moves to a review step letting the user log the full
- * time, the target only, or a typed custom value) and, from that review step, "Start again" (an
- * explicit redo that discards this attempt with nothing logged, for a mis-timed or aborted set).
- * The parent remounts this via a `key` on exerciseIndex/setIndex, so its own phase/elapsed state
- * never needs resetting by hand when the user moves to a different set.
- */
-function DurationTimer({ targetSeconds, initialSeconds, onLog }) {
-  const [phase, setPhase] = useState('idle'); // 'idle' | 'running' | 'stopped'
-  const [elapsed, setElapsed] = useState(0);
-  const [editing, setEditing] = useState(false);
-  const [customValue, setCustomValue] = useState('');
-
-  useEffect(() => {
-    if (phase !== 'running') return undefined;
-    const t = setInterval(() => setElapsed((e) => e + 1), 1000);
-    return () => clearInterval(t);
-  }, [phase]);
-
-  const hasTarget = targetSeconds > 0;
-  const overtime = hasTarget ? Math.max(0, elapsed - targetSeconds) : 0;
-  const inOvertime = hasTarget && elapsed >= targetSeconds;
-  // Fills up toward 1 as elapsed approaches the target (mirroring how the same ring fills as
-  // sets complete elsewhere), then just stays full through overtime rather than continuing past
-  // a full circle.
-  const fraction = phase === 'idle' ? 0 : hasTarget ? Math.min(1, elapsed / targetSeconds) : 0;
-
-  const start = () => {
-    setElapsed(0);
-    setEditing(false);
-    setPhase('running');
-  };
-
-  const stop = () => {
-    setPhase('stopped');
-    setEditing(false);
-    setCustomValue(String(elapsed));
-  };
-
-  if (phase === 'stopped') {
-    return (
-      <>
-        <MomentumRing fraction={fraction} interactive={false} hint="Duration set progress">
-          <span className="workout-ring-num">{elapsed}s</span>
-          <span className="workout-ring-hint">Logged</span>
-        </MomentumRing>
-        <div className="workout-duration-review">
-          {hasTarget && <span className="workout-duration-target">Target: {targetSeconds}s</span>}
-          <span className="workout-duration-review-total">{elapsed}s logged</span>
-          {editing ? (
-            <div className="workout-duration-review-edit">
-              <input
-                type="number"
-                min="0"
-                autoFocus
-                value={customValue}
-                onChange={(e) => setCustomValue(e.target.value)}
-              />
-              <button
-                type="button"
-                className="workout-duration-btn primary"
-                onClick={() => onLog(customValue === '' ? 0 : Number(customValue))}
-              >
-                Confirm
-              </button>
-            </div>
-          ) : (
-            <div className="workout-duration-review-actions">
-              <button type="button" className="workout-duration-btn primary" onClick={() => onLog(elapsed)}>
-                {overtime > 0 ? `Log full time (${elapsed}s)` : `Log time (${elapsed}s)`}
-              </button>
-              {overtime > 0 && (
-                <button type="button" className="workout-duration-btn" onClick={() => onLog(targetSeconds)}>
-                  Log target only ({targetSeconds}s)
-                </button>
-              )}
-              <div className="workout-duration-review-secondary">
-                <button type="button" className="workout-duration-btn ghost" onClick={() => setEditing(true)}>
-                  Edit custom time
-                </button>
-                <button type="button" className="workout-duration-btn ghost" onClick={start}>
-                  Start again
-                </button>
-              </div>
-            </div>
-          )}
-        </div>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <MomentumRing fraction={fraction} interactive={false} hint="Duration timer">
-        <span className={`workout-ring-num ${inOvertime ? 'overtime' : ''}`}>
-          {phase === 'idle'
-            ? `${initialSeconds ?? targetSeconds ?? 0}s`
-            : inOvertime
-              ? `+${overtime}s`
-              : `${elapsed}s`}
-        </span>
-        <span className="workout-ring-hint">
-          {phase === 'idle' ? 'Ready' : inOvertime ? 'Overtime' : hasTarget ? 'Target' : 'Elapsed'}
-        </span>
-      </MomentumRing>
-      {hasTarget && <div className="workout-duration-target">Target: {targetSeconds}s</div>}
-      <div className="workout-duration-timer">
-        {phase === 'idle' ? (
-          <button type="button" className="workout-duration-btn primary" onClick={start}>
-            Start
-          </button>
-        ) : (
-          <button type="button" className="workout-duration-btn stop" onClick={stop}>
-            Stop
-          </button>
-        )}
-      </div>
-    </>
   );
 }
 

--- a/src/db.js
+++ b/src/db.js
@@ -229,6 +229,28 @@ const MIGRATIONS = [
   },
 ];
 
+/**
+ * Defensive self-heal for a real bug seen on a device already updated to DB_VERSION 8:
+ * PRAGMA user_version had correctly advanced to 8, but the toVersion:8 ALTER TABLE statements
+ * (adding quantity_mode/auto_update_target) never actually applied, surfacing as "table tasks
+ * has no column named quantity_mode" on every routine save from then on -
+ * capacitor-community/sqlite's upgrade runner apparently doesn't guarantee the version number
+ * and the statements actually succeeding stay in lockstep if something goes wrong mid-batch.
+ * Once that happens, addUpgradeStatement's normal mechanism never retries (it only acts when
+ * the stored version is behind DB_VERSION), so this checks for the column directly - cheap,
+ * and a no-op on every device where the migration ran correctly - and adds it if missing,
+ * without requiring a destructive uninstall/reinstall to recover.
+ */
+async function ensureQuantityModeColumns(db) {
+  const info = await db.query(`PRAGMA table_info(tasks);`);
+  const hasColumn = (info.values || []).some((col) => col.name === 'quantity_mode');
+  if (hasColumn) return;
+  await db.run(`ALTER TABLE tasks ADD COLUMN quantity_mode TEXT NOT NULL DEFAULT 'number';`);
+  await db.run(`ALTER TABLE tasks ADD COLUMN auto_update_target INTEGER NOT NULL DEFAULT 0;`);
+  await db.run(`ALTER TABLE task_versions ADD COLUMN quantity_mode TEXT NOT NULL DEFAULT 'number';`);
+  await db.run(`ALTER TABLE task_versions ADD COLUMN auto_update_target INTEGER NOT NULL DEFAULT 0;`);
+}
+
 async function openDatabase() {
   const isWeb = Capacitor.getPlatform() === 'web';
   if (isWeb) {
@@ -243,6 +265,7 @@ async function openDatabase() {
     : await sqlite.createConnection(DB_NAME, false, 'no-encryption', DB_VERSION, false);
 
   await db.open();
+  await ensureQuantityModeColumns(db);
   return db;
 }
 

--- a/src/db.js
+++ b/src/db.js
@@ -2,7 +2,7 @@ import { Capacitor } from '@capacitor/core';
 import { CapacitorSQLite, SQLiteConnection } from '@capacitor-community/sqlite';
 
 const DB_NAME = 'routines';
-const DB_VERSION = 7;
+const DB_VERSION = 8;
 
 const sqlite = new SQLiteConnection(CapacitorSQLite);
 let dbInstance = null;
@@ -208,6 +208,23 @@ const MIGRATIONS = [
     statements: [
       `ALTER TABLE routines ADD COLUMN archived_at TEXT;`,
       `ALTER TABLE routine_versions ADD COLUMN archived_at TEXT;`,
+    ],
+  },
+  {
+    // A quantity task's target can now be entered/logged as a duration timer instead of a plain
+    // number - quantity_mode distinguishes the two ('number', the pre-existing behavior, stays
+    // the default so every existing quantity task renders unchanged). target/unit are unchanged
+    // by this: in 'timer' mode target still holds the same REAL column, just interpreted as
+    // whole seconds instead of an arbitrary unit amount. auto_update_target is a per-task opt-in
+    // (default off, matching every other new boolean flag added to this table so far) that lets
+    // a timer-mode quantity task raise its own target to the newly logged time whenever that time
+    // exceeds the current target - see handleLogQuantityTimer in App.jsx.
+    toVersion: 8,
+    statements: [
+      `ALTER TABLE tasks ADD COLUMN quantity_mode TEXT NOT NULL DEFAULT 'number';`,
+      `ALTER TABLE tasks ADD COLUMN auto_update_target INTEGER NOT NULL DEFAULT 0;`,
+      `ALTER TABLE task_versions ADD COLUMN quantity_mode TEXT NOT NULL DEFAULT 'number';`,
+      `ALTER TABLE task_versions ADD COLUMN auto_update_target INTEGER NOT NULL DEFAULT 0;`,
     ],
   },
 ];

--- a/src/nativeWorkoutSession.js
+++ b/src/nativeWorkoutSession.js
@@ -36,3 +36,32 @@ export function initWorkoutSetListener(onSetLogged) {
     onSetLogged(event.taskId, event.dateKey, event.exercise, event.setIndex, event.values);
   });
 }
+
+/**
+ * Launches the same native Activity/foreground-service host as a real workout session, but with
+ * a `pureTimer` payload carrying just a target - no exercises/logs/workoutLogSources at all - for
+ * a quantity task set up as a timer (RoutineForm's "Input as: Timer" mode). Reusing this host
+ * (rather than a plain setInterval running in the WebView) is what lets a long-running quantity
+ * timer survive backgrounding/screen-lock: it gets the exact same real foreground service +
+ * chronometer notification a workout session does, which a WebView-only timer has no way to get.
+ * The logged value arrives via the quantityTimerLogged listener below, not this promise (which,
+ * like startNativeWorkoutSession's, only resolves once the screen closes).
+ */
+export async function startNativeQuantityTimer(task, dateKey) {
+  if (!WorkoutSession) return null;
+  return WorkoutSession.start({
+    taskId: task.id,
+    taskTitle: task.title,
+    dateKey,
+    pureTimer: true,
+    targetSeconds: task.target || 0,
+    initialSeconds: null,
+  });
+}
+
+export function initQuantityTimerListener(onLogged) {
+  if (!WorkoutSession) return null;
+  return WorkoutSession.addListener('quantityTimerLogged', (event) => {
+    onLogged(event.taskId, event.dateKey, event.seconds);
+  });
+}

--- a/src/storage.js
+++ b/src/storage.js
@@ -20,6 +20,8 @@ function rowToTask(row) {
     target: row.target,
     unit: row.unit,
     quickAdd: row.quick_add ? JSON.parse(row.quick_add) : null,
+    quantityMode: row.quantity_mode || 'number',
+    autoUpdateTarget: Boolean(row.auto_update_target),
     exercises: row.exercises ? JSON.parse(row.exercises) : [],
     active: Boolean(row.active),
     createdAt: row.created_at,
@@ -78,8 +80,8 @@ async function insertRoutineVersion(db, routineId, fields, effectiveFrom, change
 async function insertTaskVersion(db, taskId, routineId, fields, effectiveFrom, changeType, changedFields) {
   await db.run(
     `INSERT INTO task_versions
-       (id, task_id, routine_id, effective_from, effective_to, title, time, window_start, reminder_times, days, completion_type, target, unit, quick_add, exercises, active, change_type, changed_fields)
-     VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+       (id, task_id, routine_id, effective_from, effective_to, title, time, window_start, reminder_times, days, completion_type, target, unit, quick_add, quantity_mode, auto_update_target, exercises, active, change_type, changed_fields)
+     VALUES (?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       generateId(),
       taskId,
@@ -94,6 +96,8 @@ async function insertTaskVersion(db, taskId, routineId, fields, effectiveFrom, c
       fields.target,
       fields.unit,
       fields.quick_add,
+      fields.quantity_mode,
+      fields.auto_update_target,
       fields.exercises,
       fields.active,
       changeType,
@@ -125,6 +129,8 @@ function taskFieldsOf(task) {
     target: isQuantity ? task.target ?? null : null,
     unit: isQuantity ? task.unit || null : null,
     quick_add: isQuantity && task.quickAdd?.length ? JSON.stringify(task.quickAdd) : null,
+    quantity_mode: isQuantity ? task.quantityMode || 'number' : 'number',
+    auto_update_target: isQuantity && task.autoUpdateTarget ? 1 : 0,
     exercises: JSON.stringify(isWorkout ? task.exercises || [] : []),
     active: task.active ? 1 : 0,
   };
@@ -166,13 +172,15 @@ async function migrateFromPreferencesOnce(db) {
         target: null,
         unit: null,
         quick_add: null,
+        quantity_mode: 'number',
+        auto_update_target: 0,
         exercises: '[]',
         active: r.active ? 1 : 0,
       };
       await db.run(
-        `INSERT OR REPLACE INTO tasks (id, routine_id, title, time, window_start, reminder_times, days, completion_type, target, unit, quick_add, exercises, active, deleted, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
-        [taskId, r.id, taskFields.title, taskFields.time, taskFields.window_start, taskFields.reminder_times, taskFields.days, taskFields.completion_type, taskFields.target, taskFields.unit, taskFields.quick_add, taskFields.exercises, taskFields.active, r.createdAt]
+        `INSERT OR REPLACE INTO tasks (id, routine_id, title, time, window_start, reminder_times, days, completion_type, target, unit, quick_add, quantity_mode, auto_update_target, exercises, active, deleted, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+        [taskId, r.id, taskFields.title, taskFields.time, taskFields.window_start, taskFields.reminder_times, taskFields.days, taskFields.completion_type, taskFields.target, taskFields.unit, taskFields.quick_add, taskFields.quantity_mode, taskFields.auto_update_target, taskFields.exercises, taskFields.active, r.createdAt]
       );
       await insertTaskVersion(db, taskId, r.id, taskFields, r.createdAt, 'migrated', []);
 
@@ -434,8 +442,8 @@ export async function upsertTask(task) {
 
   if (!existing) {
     await db.run(
-      `INSERT INTO tasks (id, routine_id, title, time, window_start, reminder_times, days, completion_type, target, unit, quick_add, exercises, active, deleted, created_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
+      `INSERT INTO tasks (id, routine_id, title, time, window_start, reminder_times, days, completion_type, target, unit, quick_add, quantity_mode, auto_update_target, exercises, active, deleted, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)`,
       [
         task.id,
         task.routineId,
@@ -448,6 +456,8 @@ export async function upsertTask(task) {
         fields.target,
         fields.unit,
         fields.quick_add,
+        fields.quantity_mode,
+        fields.auto_update_target,
         fields.exercises,
         fields.active,
         task.createdAt || now,
@@ -458,7 +468,7 @@ export async function upsertTask(task) {
     const changed = diffRowFields(existing, fields);
     if (changed.length > 0) {
       await db.run(
-        `UPDATE tasks SET title=?, time=?, window_start=?, reminder_times=?, days=?, completion_type=?, target=?, unit=?, quick_add=?, exercises=?, active=? WHERE id=?`,
+        `UPDATE tasks SET title=?, time=?, window_start=?, reminder_times=?, days=?, completion_type=?, target=?, unit=?, quick_add=?, quantity_mode=?, auto_update_target=?, exercises=?, active=? WHERE id=?`,
         [
           fields.title,
           fields.time,
@@ -469,6 +479,8 @@ export async function upsertTask(task) {
           fields.target,
           fields.unit,
           fields.quick_add,
+          fields.quantity_mode,
+          fields.auto_update_target,
           fields.exercises,
           fields.active,
           task.id,

--- a/src/utils/tasks.js
+++ b/src/utils/tasks.js
@@ -18,6 +18,38 @@ export function parseQuickAddText(text) {
     .filter((n) => !Number.isNaN(n) && n > 0);
 }
 
+/** Formats whole seconds as M:SS, or H:MM:SS once an hour is involved - e.g. 45 -> "0:45",
+ * 125 -> "2:05", 3665 -> "1:01:05". Used for every timer display (the live ring, target labels,
+ * review-step buttons) now that targets can run well past a minute. */
+export function formatHms(totalSeconds) {
+  const sign = totalSeconds < 0 ? '-' : '';
+  const s = Math.abs(Math.round(totalSeconds || 0));
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  const mm = hours > 0 ? String(minutes).padStart(2, '0') : String(minutes);
+  const ss = String(seconds).padStart(2, '0');
+  return hours > 0 ? `${sign}${hours}:${mm}:${ss}` : `${sign}${mm}:${ss}`;
+}
+
+/** Combines the separate hours/minutes/seconds parts typed into an HH:MM:SS setup input into the
+ * single total-seconds value that's actually persisted (task.target / exercise's
+ * targetDurationSeconds stay plain seconds either way, so this input style needed no
+ * schema/versioning change) - the inverse of secondsToHms below. */
+export function hmsToSeconds(hours, minutes, seconds) {
+  return (Number(hours) || 0) * 3600 + (Number(minutes) || 0) * 60 + (Number(seconds) || 0);
+}
+
+/** The inverse split, for prefilling an HH:MM:SS input from a stored total-seconds value. */
+export function secondsToHms(totalSeconds) {
+  const s = Math.max(0, Math.round(totalSeconds || 0));
+  return {
+    hours: Math.floor(s / 3600),
+    minutes: Math.floor((s % 3600) / 60),
+    seconds: s % 60,
+  };
+}
+
 export function isTaskDoneToday(task, completions) {
   const value = completions[task.id]?.[todayKey()];
   if (task.completionType === 'quantity') {

--- a/src/utils/tasks.test.js
+++ b/src/utils/tasks.test.js
@@ -1,6 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { todayKey } from './date.js';
-import { MAX_EXTRA_REMINDERS, isTaskDoneToday, parseQuickAddText, quickAddAmountsFor } from './tasks.js';
+import {
+  MAX_EXTRA_REMINDERS,
+  formatHms,
+  hmsToSeconds,
+  isTaskDoneToday,
+  parseQuickAddText,
+  quickAddAmountsFor,
+  secondsToHms,
+} from './tasks.js';
 
 describe('MAX_EXTRA_REMINDERS', () => {
   it('is a fixed positive integer (notification id slots depend on this being stable)', () => {
@@ -30,6 +38,37 @@ describe('parseQuickAddText', () => {
 
   it('returns an empty array for blank input', () => {
     expect(parseQuickAddText('')).toEqual([]);
+  });
+});
+
+describe('formatHms', () => {
+  it('formats under a minute as 0:SS', () => {
+    expect(formatHms(0)).toBe('0:00');
+    expect(formatHms(45)).toBe('0:45');
+  });
+
+  it('formats under an hour as M:SS', () => {
+    expect(formatHms(125)).toBe('2:05');
+    expect(formatHms(599)).toBe('9:59');
+  });
+
+  it('formats an hour or more as H:MM:SS', () => {
+    expect(formatHms(3665)).toBe('1:01:05');
+    expect(formatHms(3600)).toBe('1:00:00');
+  });
+});
+
+describe('hmsToSeconds / secondsToHms', () => {
+  it('combines separate h/m/s parts into total seconds', () => {
+    expect(hmsToSeconds(1, 2, 3)).toBe(3723);
+    expect(hmsToSeconds(0, 0, 45)).toBe(45);
+    expect(hmsToSeconds('', '', '')).toBe(0);
+  });
+
+  it('round-trips through secondsToHms', () => {
+    expect(secondsToHms(3723)).toEqual({ hours: 1, minutes: 2, seconds: 3 });
+    expect(secondsToHms(45)).toEqual({ hours: 0, minutes: 0, seconds: 45 });
+    expect(secondsToHms(0)).toEqual({ hours: 0, minutes: 0, seconds: 0 });
   });
 });
 


### PR DESCRIPTION
DurationTimer (web + native) now shows the configured target duration
alongside the live elapsed/overtime count in every phase, not just via
the ambiguous "Target" hint label. The app header also shows a tiny
version badge (native-only, reusing App.getInfo()) so the installed
build is identifiable at a glance.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MG6N4P4cx9tekqkVjLpZz8